### PR TITLE
fixed createIdent() method name, _createIdent() could not be found

### DIFF
--- a/api/app/classes/Moa/API/Provider/Magento/Category.php
+++ b/api/app/classes/Moa/API/Provider/Magento/Category.php
@@ -65,7 +65,7 @@ trait Category {
                 // Prepare the model for appending to the collection.
                 $model = array(
                     'id'            => (int) $subCategory->getId(),
-                    'ident'         => $this->_createIdent($subCategory->getName()),
+                    'ident'         => $this->createIdent($subCategory->getName()),
                     'name'          => $subCategory->getName(),
                     'productCount'  => $productCount($subCategory->getId()),
                 );


### PR DESCRIPTION
**Call to undefined method `_createIdent()`** occurs when running `phpunit` command in `api/`.
